### PR TITLE
feat: Add WebSocket support for chat completions

### DIFF
--- a/examples/websocket_client.js
+++ b/examples/websocket_client.js
@@ -1,0 +1,258 @@
+/**
+ * Example WebSocket client for LiteLLM chat completions (JavaScript/Node.js)
+ * 
+ * This demonstrates how to use the WebSocket endpoint from JavaScript/TypeScript
+ * for persistent, bidirectional communication with LiteLLM.
+ */
+
+class LiteLLMWebSocketClient {
+    constructor(url, apiKey = null) {
+        this.url = url;
+        this.apiKey = apiKey;
+        this.ws = null;
+        this.messageHandlers = new Map();
+    }
+
+    /**
+     * Connect to the WebSocket server
+     */
+    connect() {
+        return new Promise((resolve, reject) => {
+            // For Node.js, use 'ws' library
+            // For browser, use native WebSocket
+            if (typeof window === 'undefined') {
+                // Node.js environment
+                const WebSocket = require('ws');
+                const headers = {};
+                if (this.apiKey) {
+                    headers['Authorization'] = `Bearer ${this.apiKey}`;
+                }
+                this.ws = new WebSocket(this.url, { headers });
+            } else {
+                // Browser environment
+                this.ws = new WebSocket(this.url);
+            }
+
+            this.ws.onopen = () => {
+                console.log(`Connected to ${this.url}`);
+                resolve();
+            };
+
+            this.ws.onerror = (error) => {
+                console.error('WebSocket error:', error);
+                reject(error);
+            };
+
+            this.ws.onmessage = (event) => {
+                const data = JSON.parse(event.data);
+                this.handleMessage(data);
+            };
+
+            this.ws.onclose = () => {
+                console.log('Disconnected from server');
+            };
+        });
+    }
+
+    /**
+     * Disconnect from the WebSocket server
+     */
+    disconnect() {
+        if (this.ws) {
+            this.ws.close();
+        }
+    }
+
+    /**
+     * Send a chat completion request
+     */
+    async sendChatCompletion(options) {
+        const {
+            model,
+            messages,
+            stream = true,
+            temperature = null,
+            maxTokens = null,
+            onChunk = null,
+            ...additionalParams
+        } = options;
+
+        const requestId = this.generateUUID();
+
+        // Build request message
+        const request = {
+            type: 'chat_completion',
+            request_id: requestId,
+            model,
+            messages,
+            stream,
+            ...additionalParams
+        };
+
+        if (temperature !== null) {
+            request.temperature = temperature;
+        }
+        if (maxTokens !== null) {
+            request.max_tokens = maxTokens;
+        }
+
+        // Set up response handler
+        return new Promise((resolve, reject) => {
+            let fullResponse = '';
+
+            this.messageHandlers.set(requestId, (data) => {
+                if (data.type === 'error') {
+                    reject(new Error(data.error));
+                    this.messageHandlers.delete(requestId);
+                } else if (data.type === 'stream_chunk' && stream) {
+                    const chunk = data.data;
+                    if (chunk.choices && chunk.choices[0]?.delta?.content) {
+                        const content = chunk.choices[0].delta.content;
+                        fullResponse += content;
+                        if (onChunk) {
+                            onChunk(content);
+                        }
+                    }
+                } else if (data.type === 'stream_complete' && stream) {
+                    resolve(fullResponse);
+                    this.messageHandlers.delete(requestId);
+                } else if (data.type === 'completion' && !stream) {
+                    const completion = data.data;
+                    if (completion.choices && completion.choices[0]?.message?.content) {
+                        resolve(completion.choices[0].message.content);
+                    } else {
+                        resolve(completion);
+                    }
+                    this.messageHandlers.delete(requestId);
+                }
+            });
+
+            // Send request
+            this.ws.send(JSON.stringify(request));
+            console.log(`Sent request ${requestId}`);
+        });
+    }
+
+    /**
+     * Send a ping message to keep connection alive
+     */
+    async ping() {
+        return new Promise((resolve, reject) => {
+            const pingId = this.generateUUID();
+            
+            this.messageHandlers.set(pingId, (data) => {
+                if (data.type === 'pong') {
+                    console.log('Received pong');
+                    resolve();
+                    this.messageHandlers.delete(pingId);
+                }
+            });
+
+            this.ws.send(JSON.stringify({ type: 'ping', request_id: pingId }));
+            
+            // Timeout after 5 seconds
+            setTimeout(() => {
+                if (this.messageHandlers.has(pingId)) {
+                    this.messageHandlers.delete(pingId);
+                    reject(new Error('Ping timeout'));
+                }
+            }, 5000);
+        });
+    }
+
+    /**
+     * Handle incoming messages
+     */
+    handleMessage(data) {
+        const requestId = data.request_id;
+        if (requestId && this.messageHandlers.has(requestId)) {
+            this.messageHandlers.get(requestId)(data);
+        }
+    }
+
+    /**
+     * Generate a UUID
+     */
+    generateUUID() {
+        return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+            const r = Math.random() * 16 | 0;
+            const v = c === 'x' ? r : (r & 0x3 | 0x8);
+            return v.toString(16);
+        });
+    }
+}
+
+// Example usage
+async function main() {
+    // Configure your LiteLLM server URL and API key
+    const URL = 'ws://localhost:4000/v1/chat/completions/ws';
+    const API_KEY = 'your-api-key-here'; // Optional, if authentication is enabled
+
+    // Create client
+    const client = new LiteLLMWebSocketClient(URL, API_KEY);
+
+    try {
+        // Connect to server
+        await client.connect();
+
+        // Example 1: Streaming chat completion with chunk handler
+        console.log('\n=== Streaming Chat Completion ===');
+        const response1 = await client.sendChatCompletion({
+            model: 'gpt-3.5-turbo',
+            messages: [
+                { role: 'system', content: 'You are a helpful assistant.' },
+                { role: 'user', content: 'Write a haiku about WebSockets' }
+            ],
+            stream: true,
+            temperature: 0.7,
+            onChunk: (chunk) => {
+                process.stdout.write(chunk); // Print chunks as they arrive
+            }
+        });
+        console.log('\n[Stream complete]');
+
+        // Example 2: Non-streaming chat completion
+        console.log('\n=== Non-Streaming Chat Completion ===');
+        const response2 = await client.sendChatCompletion({
+            model: 'gpt-3.5-turbo',
+            messages: [
+                { role: 'user', content: 'What is 2+2?' }
+            ],
+            stream: false
+        });
+        console.log('Response:', response2);
+
+        // Example 3: Multiple requests on same connection
+        console.log('\n=== Multiple Requests ===');
+        for (let i = 0; i < 3; i++) {
+            console.log(`\nRequest ${i + 1}:`);
+            const response = await client.sendChatCompletion({
+                model: 'gpt-3.5-turbo',
+                messages: [
+                    { role: 'user', content: 'Generate a random number between 1 and 100' }
+                ],
+                stream: false
+            });
+            console.log('Response:', response);
+        }
+
+        // Keep connection alive with ping
+        await client.ping();
+
+    } catch (error) {
+        console.error('Error:', error);
+    } finally {
+        // Disconnect
+        client.disconnect();
+    }
+}
+
+// Run the example
+if (require.main === module) {
+    main().catch(console.error);
+}
+
+// Export for use as a module
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = LiteLLMWebSocketClient;
+}

--- a/examples/websocket_client.py
+++ b/examples/websocket_client.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""
+Example WebSocket client for LiteLLM chat completions
+
+This demonstrates how to use the WebSocket endpoint for persistent,
+bidirectional communication with LiteLLM.
+"""
+
+import asyncio
+import json
+import uuid
+import websockets
+from typing import Optional
+
+
+class LiteLLMWebSocketClient:
+    """WebSocket client for LiteLLM chat completions"""
+    
+    def __init__(self, url: str, api_key: Optional[str] = None):
+        """
+        Initialize WebSocket client
+        
+        Args:
+            url: WebSocket URL (e.g., "ws://localhost:4000/v1/chat/completions/ws")
+            api_key: Optional API key for authentication
+        """
+        self.url = url
+        self.api_key = api_key
+        self.websocket = None
+        
+    async def connect(self):
+        """Connect to the WebSocket server"""
+        headers = {}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+            
+        self.websocket = await websockets.connect(self.url, extra_headers=headers)
+        print(f"Connected to {self.url}")
+        
+    async def disconnect(self):
+        """Disconnect from the WebSocket server"""
+        if self.websocket:
+            await self.websocket.close()
+            print("Disconnected from server")
+            
+    async def send_chat_completion(
+        self,
+        model: str,
+        messages: list,
+        stream: bool = True,
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+        **kwargs
+    ):
+        """
+        Send a chat completion request
+        
+        Args:
+            model: Model to use
+            messages: List of message dicts
+            stream: Whether to stream the response
+            temperature: Optional temperature
+            max_tokens: Optional max tokens
+            **kwargs: Additional parameters
+        """
+        request_id = str(uuid.uuid4())
+        
+        # Build request message
+        request = {
+            "type": "chat_completion",
+            "request_id": request_id,
+            "model": model,
+            "messages": messages,
+            "stream": stream
+        }
+        
+        if temperature is not None:
+            request["temperature"] = temperature
+        if max_tokens is not None:
+            request["max_tokens"] = max_tokens
+            
+        # Add any additional parameters
+        request.update(kwargs)
+        
+        # Send request
+        await self.websocket.send(json.dumps(request))
+        print(f"Sent request {request_id}")
+        
+        # Handle response
+        if stream:
+            await self._handle_streaming_response(request_id)
+        else:
+            await self._handle_single_response(request_id)
+            
+    async def _handle_streaming_response(self, request_id: str):
+        """Handle a streaming response"""
+        full_response = ""
+        
+        while True:
+            response = await self.websocket.recv()
+            data = json.loads(response)
+            
+            if data.get("type") == "error":
+                print(f"Error: {data.get('error')}")
+                break
+            elif data.get("type") == "stream_chunk" and data.get("request_id") == request_id:
+                chunk = data.get("data", {})
+                # Extract content from chunk
+                if "choices" in chunk and len(chunk["choices"]) > 0:
+                    delta = chunk["choices"][0].get("delta", {})
+                    content = delta.get("content", "")
+                    if content:
+                        print(content, end="", flush=True)
+                        full_response += content
+            elif data.get("type") == "stream_complete" and data.get("request_id") == request_id:
+                print("\n[Stream complete]")
+                break
+                
+        return full_response
+        
+    async def _handle_single_response(self, request_id: str):
+        """Handle a non-streaming response"""
+        while True:
+            response = await self.websocket.recv()
+            data = json.loads(response)
+            
+            if data.get("type") == "error":
+                print(f"Error: {data.get('error')}")
+                break
+            elif data.get("type") == "completion" and data.get("request_id") == request_id:
+                completion = data.get("data", {})
+                if "choices" in completion and len(completion["choices"]) > 0:
+                    content = completion["choices"][0]["message"]["content"]
+                    print(f"Response: {content}")
+                    return content
+                break
+                
+    async def send_ping(self):
+        """Send a ping message to keep connection alive"""
+        await self.websocket.send(json.dumps({"type": "ping"}))
+        response = await self.websocket.recv()
+        data = json.loads(response)
+        if data.get("type") == "pong":
+            print("Received pong")
+
+
+async def main():
+    """Example usage of the WebSocket client"""
+    
+    # Configure your LiteLLM server URL and API key
+    URL = "ws://localhost:4000/v1/chat/completions/ws"
+    API_KEY = "your-api-key-here"  # Optional, if authentication is enabled
+    
+    # Create client
+    client = LiteLLMWebSocketClient(URL, API_KEY)
+    
+    try:
+        # Connect to server
+        await client.connect()
+        
+        # Example 1: Streaming chat completion
+        print("\n=== Streaming Chat Completion ===")
+        await client.send_chat_completion(
+            model="gpt-3.5-turbo",
+            messages=[
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": "Write a haiku about WebSockets"}
+            ],
+            stream=True,
+            temperature=0.7
+        )
+        
+        # Example 2: Non-streaming chat completion
+        print("\n=== Non-Streaming Chat Completion ===")
+        await client.send_chat_completion(
+            model="gpt-3.5-turbo",
+            messages=[
+                {"role": "user", "content": "What is 2+2?"}
+            ],
+            stream=False
+        )
+        
+        # Example 3: Multiple requests on same connection
+        print("\n=== Multiple Requests ===")
+        for i in range(3):
+            print(f"\nRequest {i+1}:")
+            await client.send_chat_completion(
+                model="gpt-3.5-turbo",
+                messages=[
+                    {"role": "user", "content": f"Generate a random number between 1 and 100"}
+                ],
+                stream=False
+            )
+            
+        # Keep connection alive with ping
+        await client.send_ping()
+        
+    finally:
+        # Disconnect
+        await client.disconnect()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/litellm/proxy/websocket_handler.py
+++ b/litellm/proxy/websocket_handler.py
@@ -1,0 +1,184 @@
+"""
+WebSocket handler for general client access to LiteLLM
+Provides persistent bidirectional communication for chat completions
+"""
+
+import asyncio
+import json
+import traceback
+import uuid
+from typing import Any, Dict, Optional
+
+from fastapi import WebSocket, WebSocketDisconnect
+from litellm import acompletion
+from litellm.proxy._types import ProxyException
+from litellm.proxy.utils import verbose_proxy_logger
+
+
+class WebSocketConnectionManager:
+    """Manages WebSocket connections and message routing"""
+    
+    def __init__(self):
+        self.active_connections: Dict[str, WebSocket] = {}
+        
+    async def connect(self, websocket: WebSocket, client_id: str):
+        """Accept and store a new WebSocket connection"""
+        await websocket.accept()
+        self.active_connections[client_id] = websocket
+        verbose_proxy_logger.info(f"WebSocket client {client_id} connected")
+        
+    def disconnect(self, client_id: str):
+        """Remove a WebSocket connection"""
+        if client_id in self.active_connections:
+            del self.active_connections[client_id]
+            verbose_proxy_logger.info(f"WebSocket client {client_id} disconnected")
+            
+    async def send_message(self, client_id: str, message: dict):
+        """Send a message to a specific client"""
+        if client_id in self.active_connections:
+            websocket = self.active_connections[client_id]
+            await websocket.send_json(message)
+            
+    async def send_error(self, client_id: str, error: str, request_id: Optional[str] = None):
+        """Send an error message to a client"""
+        error_message = {
+            "type": "error",
+            "error": error,
+            "request_id": request_id
+        }
+        await self.send_message(client_id, error_message)
+
+
+class WebSocketChatHandler:
+    """Handles chat completion requests over WebSocket"""
+    
+    def __init__(self, manager: WebSocketConnectionManager):
+        self.manager = manager
+        
+    async def handle_chat_completion(
+        self,
+        client_id: str,
+        message: dict,
+        user_api_key_dict: dict,
+        llm_router: Any,
+        proxy_config: Any
+    ):
+        """Process a chat completion request"""
+        request_id = message.get("request_id", str(uuid.uuid4()))
+        
+        try:
+            # Extract parameters from message
+            model = message.get("model")
+            messages = message.get("messages", [])
+            stream = message.get("stream", True)
+            temperature = message.get("temperature")
+            max_tokens = message.get("max_tokens")
+            
+            if not model:
+                await self.manager.send_error(client_id, "Model is required", request_id)
+                return
+                
+            if not messages:
+                await self.manager.send_error(client_id, "Messages are required", request_id)
+                return
+            
+            # Prepare completion parameters
+            completion_params = {
+                "model": model,
+                "messages": messages,
+                "stream": stream,
+                "user": user_api_key_dict.get("user_id"),
+                "api_key": user_api_key_dict.get("api_key"),
+            }
+            
+            if temperature is not None:
+                completion_params["temperature"] = temperature
+            if max_tokens is not None:
+                completion_params["max_tokens"] = max_tokens
+                
+            # Add any additional parameters from the message
+            for key in ["top_p", "n", "stop", "presence_penalty", "frequency_penalty", "logit_bias"]:
+                if key in message:
+                    completion_params[key] = message[key]
+            
+            if stream:
+                # Handle streaming response
+                response = await acompletion(**completion_params, router=llm_router)
+                
+                async for chunk in response:
+                    chunk_dict = chunk.model_dump() if hasattr(chunk, 'model_dump') else chunk
+                    await self.manager.send_message(client_id, {
+                        "type": "stream_chunk",
+                        "request_id": request_id,
+                        "data": chunk_dict
+                    })
+                    
+                # Send completion signal
+                await self.manager.send_message(client_id, {
+                    "type": "stream_complete",
+                    "request_id": request_id
+                })
+            else:
+                # Handle non-streaming response
+                response = await acompletion(**completion_params, router=llm_router)
+                response_dict = response.model_dump() if hasattr(response, 'model_dump') else response
+                
+                await self.manager.send_message(client_id, {
+                    "type": "completion",
+                    "request_id": request_id,
+                    "data": response_dict
+                })
+                
+        except ProxyException as e:
+            await self.manager.send_error(client_id, str(e), request_id)
+        except Exception as e:
+            verbose_proxy_logger.exception(f"Error in WebSocket chat completion: {str(e)}")
+            await self.manager.send_error(client_id, f"Internal error: {str(e)}", request_id)
+
+
+async def handle_websocket_client(
+    websocket: WebSocket,
+    user_api_key_dict: dict,
+    llm_router: Any,
+    proxy_config: Any
+):
+    """Main handler for WebSocket client connections"""
+    client_id = str(uuid.uuid4())
+    manager = WebSocketConnectionManager()
+    chat_handler = WebSocketChatHandler(manager)
+    
+    await manager.connect(websocket, client_id)
+    
+    try:
+        while True:
+            # Receive message from client
+            data = await websocket.receive_text()
+            
+            try:
+                message = json.loads(data)
+            except json.JSONDecodeError:
+                await manager.send_error(client_id, "Invalid JSON format")
+                continue
+                
+            message_type = message.get("type")
+            
+            if message_type == "chat_completion":
+                # Handle chat completion request
+                await chat_handler.handle_chat_completion(
+                    client_id,
+                    message,
+                    user_api_key_dict,
+                    llm_router,
+                    proxy_config
+                )
+            elif message_type == "ping":
+                # Respond to ping with pong
+                await manager.send_message(client_id, {"type": "pong"})
+            else:
+                await manager.send_error(client_id, f"Unknown message type: {message_type}")
+                
+    except WebSocketDisconnect:
+        manager.disconnect(client_id)
+    except Exception as e:
+        verbose_proxy_logger.exception(f"WebSocket error: {str(e)}")
+        manager.disconnect(client_id)


### PR DESCRIPTION
- Add new WebSocket endpoints /v1/chat/completions/ws and /chat/completions/ws
- Implement bidirectional message handling for persistent connections
- Support both streaming and non-streaming responses
- Add authentication via existing user_api_key_auth_websocket
- Include Python and JavaScript example clients
- Enable multiple concurrent requests per connection

This allows clients to maintain persistent connections for lower latency and more efficient resource usage, ideal for chat applications and interactive AI personalities.

## Title

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes


